### PR TITLE
Set up WordPress Coding Standards tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ OKFNWP is a WordPress theme built on Bootstrap.
 
 **You'll need the following installed before continuing:**
 
-* [Node.js](http://nodejs.org): Use the installer provided on the NodeJS website.
-* [Grunt](http://gruntjs.com/): Run `[sudo] npm install -g grunt-cli`
+- [Node.js](http://nodejs.org): Use the installer provided on the NodeJS website.
+- [Grunt](http://gruntjs.com/): Run `[sudo] npm install -g grunt-cli`
 
 To get started run:
 
@@ -25,8 +25,56 @@ The homepage template is a regular full-width content page. Use the `[latestpost
 
 To add a 3-column row of the latest blog posts, use:
 
-  `[latestposts]`
+`[latestposts]`
 
 To change the section heading from the default 'Latest posts from the blog', pass in a title="" parameter:
 
 `[latestposts title="Recent Posts"]`
+
+## Coding Standards
+
+Uses [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer/) as the basis, along with [WordPress Coding Standards](https://github.com/WordPress/WordPress-Coding-Standards). [PHPCSUtils](https://github.com/PHPCSStandards/PHPCSUtils) and [PHPCSExtra](https://github.com/PHPCSStandards/PHPCSExtra) are also required.
+
+### Setup
+
+Make sure you are running PHP CodeSniffer 3.7 or above. Clone it from GitHub and add its binaries to the relevant system folders, so you can use `phpcs` or `phpcbf`, without the need to specify the exact path to the binary.
+
+1. Clone https://github.com/squizlabs/PHP_CodeSniffer/ to your home folder.
+2. Set symlinks to the binaries of `phpcs` and `phpcbf` container in `~/PHP_CodeSniffer/bin/` with the following commands in any Linux distribution.
+
+```sh
+sudo ln -s ~/PHP_CodeSniffer/bin/phpcs /usr/bin
+sudo ln -s ~/PHP_CodeSniffer/bin/phpcbf /usr/bin
+```
+
+Once symlinks are created, try to execute `phpcs` in the terminal. You should get the following output and it means that you're all set to use PHP CodeSniffer.
+
+```sh
+ERROR: You must supply at least one file or directory to process.
+
+Run "phpcs --help" for usage information
+```
+
+3. Next, clone https://github.com/WordPress/WordPress-Coding-Standards to your home folder in a subfolder called `wpcs` for your convenience.
+
+4. Clone https://github.com/PHPCSStandards/PHPCSUtils to your home folder
+
+5. Clone https://github.com/PHPCSStandards/PHPCSExtra to your home folder
+
+6. The only thing left to do is to make sure `phpcs` uses these extra sniffs and knows where to find them. We do that by updating it configuration.
+
+```sh
+phpcs --config-set installed_paths ~/wpcs,~/PHPCSUtils/PHPCSUtils,~/PHPCSExtra
+```
+
+If the configuration is properly updated, you should get the following output when executing `phpcs -i`.
+
+```sh
+The installed coding standards are MySource, PEAR, PSR1, PSR2, PSR12, Squiz, Zend, WordPress, WordPress-Core, WordPress-Docs, WordPress-Extra, PHPCSUtils, NormalizedArrays and Universal
+```
+
+If something is not right and you can't get it to work, use `phpcs --config-show` to see what you have PHP CodeSniffer configured with.
+
+### Testing
+
+Just run `./run_tests.sh` and follow the output. Test will find all kinds of errors and the simple ones will be corrected automatically. For the other ones you'll need to rerun the tests to confirm they have been resolved.

--- a/package.json
+++ b/package.json
@@ -3,8 +3,11 @@
 	"title": "Open Knowledge WordPress Theme",
 	"description": "",
 	"version": "1.0.0",
-	"author": {},
-	"repository": {},
+	"author": "Open Knowledge Foundation",
+	"repository": {
+		"type": "git",
+		"url": "git@github.com:okfn/wordpress-theme.git"
+	},
 	"engines": {
 		"node": ">=0.10.25",
 		"npm": ">=1.4.4"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Example Project" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
+	<description>A custom set of rules to check for a WPized WordPress project</description>
+
+	<!-- Exclude WP Core folders and files from being checked. -->
+	<exclude-pattern>/docroot/wp-admin/*</exclude-pattern>
+	<exclude-pattern>/docroot/wp-includes/*</exclude-pattern>
+	<exclude-pattern>/docroot/wp-*.php</exclude-pattern>
+	<exclude-pattern>/docroot/index.php</exclude-pattern>
+	<exclude-pattern>/docroot/xmlrpc.php</exclude-pattern>
+	<exclude-pattern>/docroot/wp-content/plugins/*</exclude-pattern>
+
+	<!-- Exclude the Composer Vendor directory. -->
+	<exclude-pattern>/vendor/*</exclude-pattern>
+
+	<!-- Exclude the Node Modules directory. -->
+	<exclude-pattern>/node_modules/*</exclude-pattern>
+
+	<!-- Exclude minified Javascript files. -->
+	<exclude-pattern>*.min.js</exclude-pattern>
+
+	<!-- Exclude Bower component files. -->
+	<exclude-pattern>/bower_components/*</exclude-pattern>
+
+	<!-- Include the WordPress-Extra standard. -->
+	<rule ref="WordPress-Extra">
+		<!--
+		We may want a middle ground though. The best way to do this is add the
+		entire ruleset, then rule by rule, remove ones that don't suit a project.
+		We can do this by running `phpcs` with the '-s' flag, which allows us to
+		see the names of the sniffs reporting errors.
+		Once we know the sniff names, we can opt to exclude sniffs which don't
+		suit our project like so.
+		The below two examples just show how you can exclude rules.
+		They are not intended as advice about which sniffs to exclude.
+		-->
+
+		<!--
+		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing"/>
+		<exclude name="WordPress.Security.EscapeOutput"/>
+		-->
+	</rule>
+
+	<!-- Let's also check that everything is properly documented. -->
+	<rule ref="WordPress-Docs"/>
+
+	<!-- Add in some extra rules from other standards. -->
+	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
+	<rule ref="Generic.Commenting.Todo"/>
+
+	<!-- Check for PHP cross-version compatibility. -->
+	<!--
+	To enable this, the PHPCompatibilityWP standard needs
+	to be installed.
+	See the readme for installation instructions:
+	https://github.com/PHPCompatibility/PHPCompatibilityWP
+	For more information, also see:
+	https://github.com/PHPCompatibility/PHPCompatibility
+	-->
+	<!--
+	<config name="testVersion" value="5.2-"/>
+	<rule ref="PHPCompatibilityWP"/>
+	-->
+
+	<!--
+	To get the optimal benefits of using WPCS, we should add a couple of
+	custom properties.
+	Adjust the values of these properties to fit our needs.
+	For information on additional custom properties available, check out
+	the wiki:
+	https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties
+	-->
+	<config name="minimum_supported_wp_version" value="4.9"/>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="okf-theme"/>
+				<element value="library-textdomain"/>
+			</property>
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array">
+				<element value="okf"/>
+			</property>
+		</properties>
+	</rule>
+
+</ruleset>

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Search for PHP syntax errors.
+find -L . -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
+
+# WordPress Coding Standards.
+phpcs -p -s -v -n . --standard=./phpcs.xml --extensions=php
+
+# Automatically fix PHP syntax errors.
+phpcbf . --standard=./phpcs.xml --extensions=php


### PR DESCRIPTION
This PR adds scripts for testing PHP files for the WordPress Coding Standards with PHP CodeSniffer. Setup documentation is also included.