### PR TITLE
Use a real URL, not a HTML <img> tag

### DIFF
--- a/header.php
+++ b/header.php
@@ -24,7 +24,7 @@
 			$twitter_desc   = get_the_excerpt();
 
 			if ( has_post_thumbnail() ) {
-				$twitter_thumb = get_the_post_thumbnail( $post, 'small' );
+				$twitter_thumb = get_the_post_thumbnail_url();
 			} elseif ( okfn_get_first_image_url_from_post_content() ) {
 				$twitter_thumb = okfn_get_first_image_url_from_post_content();
 			} else {


### PR DESCRIPTION
By mistake, we are using the HTML `<img>` tag instead the actual URL for the thumbnail

![image](https://user-images.githubusercontent.com/3237309/197249556-7a260988-2777-4a79-a2aa-664aad00b5e8.png)

This PR fixes the error